### PR TITLE
Upgrade Ruby from 2.1.9 to 2.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.9'
+ruby '2.2.5'
 
 group :development do
   gem 'recap'


### PR DESCRIPTION
This is in preparation for upgrading Ruby on our Linode box.

Please do not merge.